### PR TITLE
Refactor plan format to support steps and operators

### DIFF
--- a/core/planfmt/fuzz_test.go
+++ b/core/planfmt/fuzz_test.go
@@ -73,12 +73,17 @@ func addSeedCorpus(f *testing.F) {
 			name: "single_step",
 			plan: &planfmt.Plan{
 				Target: "build",
-				Root: &planfmt.Step{
-					ID:   1,
-					Kind: planfmt.KindDecorator,
-					Op:   "shell",
-					Args: []planfmt.Arg{
-						{Key: "cmd", Val: planfmt.Value{Kind: planfmt.ValueString, Str: "echo test"}},
+				Steps: []planfmt.Step{
+					{
+						ID: 1,
+						Commands: []planfmt.Command{
+							{
+								Decorator: "@shell",
+								Args: []planfmt.Arg{
+									{Key: "cmd", Val: planfmt.Value{Kind: planfmt.ValueString, Str: "echo test"}},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -87,13 +92,28 @@ func addSeedCorpus(f *testing.F) {
 			name: "nested_steps",
 			plan: &planfmt.Plan{
 				Target: "parallel",
-				Root: &planfmt.Step{
-					ID:   1,
-					Kind: planfmt.KindDecorator,
-					Op:   "parallel",
-					Children: []*planfmt.Step{
-						{ID: 2, Kind: planfmt.KindDecorator, Op: "task1"},
-						{ID: 3, Kind: planfmt.KindDecorator, Op: "task2"},
+				Steps: []planfmt.Step{
+					{
+						ID: 1,
+						Commands: []planfmt.Command{
+							{
+								Decorator: "@parallel",
+								Block: []planfmt.Step{
+									{
+										ID: 2,
+										Commands: []planfmt.Command{
+											{Decorator: "@task1"},
+										},
+									},
+									{
+										ID: 3,
+										Commands: []planfmt.Command{
+											{Decorator: "@task2"},
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -102,15 +122,20 @@ func addSeedCorpus(f *testing.F) {
 			name: "all_value_types",
 			plan: &planfmt.Plan{
 				Target: "types",
-				Root: &planfmt.Step{
-					ID:   1,
-					Kind: planfmt.KindDecorator,
-					Op:   "test",
-					Args: []planfmt.Arg{
-						{Key: "a_bool", Val: planfmt.Value{Kind: planfmt.ValueBool, Bool: true}},
-						{Key: "b_int", Val: planfmt.Value{Kind: planfmt.ValueInt, Int: -42}},
-						{Key: "c_str", Val: planfmt.Value{Kind: planfmt.ValueString, Str: "hello"}},
-						{Key: "d_ref", Val: planfmt.Value{Kind: planfmt.ValuePlaceholder, Ref: 0}},
+				Steps: []planfmt.Step{
+					{
+						ID: 1,
+						Commands: []planfmt.Command{
+							{
+								Decorator: "@test",
+								Args: []planfmt.Arg{
+									{Key: "a_bool", Val: planfmt.Value{Kind: planfmt.ValueBool, Bool: true}},
+									{Key: "b_int", Val: planfmt.Value{Kind: planfmt.ValueInt, Int: -42}},
+									{Key: "c_str", Val: planfmt.Value{Kind: planfmt.ValueString, Str: "hello"}},
+									{Key: "d_ref", Val: planfmt.Value{Kind: planfmt.ValuePlaceholder, Ref: 0}},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/core/planfmt/hash_test.go
+++ b/core/planfmt/hash_test.go
@@ -17,12 +17,17 @@ func TestHashDeterminism(t *testing.T) {
 			Compiler:  [16]byte{16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1},
 			PlanKind:  1,
 		},
-		Root: &planfmt.Step{
-			ID:   1,
-			Kind: planfmt.KindDecorator,
-			Op:   "shell",
-			Args: []planfmt.Arg{
-				{Key: "cmd", Val: planfmt.Value{Kind: planfmt.ValueString, Str: "echo test"}},
+		Steps: []planfmt.Step{
+			{
+				ID: 1,
+				Commands: []planfmt.Command{
+					{
+						Decorator: "@shell",
+						Args: []planfmt.Arg{
+							{Key: "cmd", Val: planfmt.Value{Kind: planfmt.ValueString, Str: "echo test"}},
+						},
+					},
+				},
 			},
 		},
 	}
@@ -76,21 +81,27 @@ func TestHashUniqueness(t *testing.T) {
 			name: "with_step",
 			plan: &planfmt.Plan{
 				Target: "deploy",
-				Root: &planfmt.Step{
-					ID:   1,
-					Kind: planfmt.KindDecorator,
-					Op:   "shell",
+				Steps: []planfmt.Step{
+					{
+						ID: 1,
+						Commands: []planfmt.Command{
+							{Decorator: "@shell"},
+						},
+					},
 				},
 			},
 		},
 		{
-			name: "different_op",
+			name: "different_decorator",
 			plan: &planfmt.Plan{
 				Target: "deploy",
-				Root: &planfmt.Step{
-					ID:   1,
-					Kind: planfmt.KindDecorator,
-					Op:   "retry",
+				Steps: []planfmt.Step{
+					{
+						ID: 1,
+						Commands: []planfmt.Command{
+							{Decorator: "@retry"},
+						},
+					},
 				},
 			},
 		},
@@ -118,12 +129,17 @@ func TestHashUniqueness(t *testing.T) {
 func TestHashRoundTrip(t *testing.T) {
 	plan := &planfmt.Plan{
 		Target: "test",
-		Root: &planfmt.Step{
-			ID:   1,
-			Kind: planfmt.KindDecorator,
-			Op:   "shell",
-			Args: []planfmt.Arg{
-				{Key: "cmd", Val: planfmt.Value{Kind: planfmt.ValueString, Str: "echo hello"}},
+		Steps: []planfmt.Step{
+			{
+				ID: 1,
+				Commands: []planfmt.Command{
+					{
+						Decorator: "@shell",
+						Args: []planfmt.Arg{
+							{Key: "cmd", Val: planfmt.Value{Kind: planfmt.ValueString, Str: "echo hello"}},
+						},
+					},
+				},
 			},
 		},
 	}

--- a/core/planfmt/roundtrip_test.go
+++ b/core/planfmt/roundtrip_test.go
@@ -41,12 +41,17 @@ func TestRoundTrip(t *testing.T) {
 					CreatedAt: 9876543210,
 					PlanKind:  1,
 				},
-				Root: &planfmt.Step{
-					ID:   1,
-					Kind: planfmt.KindDecorator,
-					Op:   "shell",
-					Args: []planfmt.Arg{
-						{Key: "cmd", Val: planfmt.Value{Kind: planfmt.ValueString, Str: "echo hello"}},
+				Steps: []planfmt.Step{
+					{
+						ID: 1,
+						Commands: []planfmt.Command{
+							{
+								Decorator: "@shell",
+								Args: []planfmt.Arg{
+									{Key: "cmd", Val: planfmt.Value{Kind: planfmt.ValueString, Str: "echo hello"}},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -55,25 +60,36 @@ func TestRoundTrip(t *testing.T) {
 			name: "plan with nested steps",
 			plan: &planfmt.Plan{
 				Target: "test",
-				Root: &planfmt.Step{
-					ID:   1,
-					Kind: planfmt.KindDecorator,
-					Op:   "parallel",
-					Children: []*planfmt.Step{
-						{
-							ID:   2,
-							Kind: planfmt.KindDecorator,
-							Op:   "shell",
-							Args: []planfmt.Arg{
-								{Key: "cmd", Val: planfmt.Value{Kind: planfmt.ValueString, Str: "task1"}},
-							},
-						},
-						{
-							ID:   3,
-							Kind: planfmt.KindDecorator,
-							Op:   "shell",
-							Args: []planfmt.Arg{
-								{Key: "cmd", Val: planfmt.Value{Kind: planfmt.ValueString, Str: "task2"}},
+				Steps: []planfmt.Step{
+					{
+						ID: 1,
+						Commands: []planfmt.Command{
+							{
+								Decorator: "@parallel",
+								Block: []planfmt.Step{
+									{
+										ID: 2,
+										Commands: []planfmt.Command{
+											{
+												Decorator: "@shell",
+												Args: []planfmt.Arg{
+													{Key: "cmd", Val: planfmt.Value{Kind: planfmt.ValueString, Str: "task1"}},
+												},
+											},
+										},
+									},
+									{
+										ID: 3,
+										Commands: []planfmt.Command{
+											{
+												Decorator: "@shell",
+												Args: []planfmt.Arg{
+													{Key: "cmd", Val: planfmt.Value{Kind: planfmt.ValueString, Str: "task2"}},
+												},
+											},
+										},
+									},
+								},
 							},
 						},
 					},
@@ -84,14 +100,19 @@ func TestRoundTrip(t *testing.T) {
 			name: "plan with all value types",
 			plan: &planfmt.Plan{
 				Target: "complex",
-				Root: &planfmt.Step{
-					ID:   1,
-					Kind: planfmt.KindDecorator,
-					Op:   "test",
-					Args: []planfmt.Arg{
-						{Key: "bool_val", Val: planfmt.Value{Kind: planfmt.ValueBool, Bool: true}},
-						{Key: "int_val", Val: planfmt.Value{Kind: planfmt.ValueInt, Int: 42}},
-						{Key: "str_val", Val: planfmt.Value{Kind: planfmt.ValueString, Str: "hello"}},
+				Steps: []planfmt.Step{
+					{
+						ID: 1,
+						Commands: []planfmt.Command{
+							{
+								Decorator: "@test",
+								Args: []planfmt.Arg{
+									{Key: "bool_val", Val: planfmt.Value{Kind: planfmt.ValueBool, Bool: true}},
+									{Key: "int_val", Val: planfmt.Value{Kind: planfmt.ValueInt, Int: 42}},
+									{Key: "str_val", Val: planfmt.Value{Kind: planfmt.ValueString, Str: "hello"}},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -155,29 +176,40 @@ func TestRoundTripPreservesSemantics(t *testing.T) {
 			Compiler:  [16]byte{16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1},
 			PlanKind:  1,
 		},
-		Root: &planfmt.Step{
-			ID:   1,
-			Kind: planfmt.KindDecorator,
-			Op:   "parallel",
-			Args: []planfmt.Arg{
-				{Key: "max_concurrent", Val: planfmt.Value{Kind: planfmt.ValueInt, Int: 4}},
-			},
-			Children: []*planfmt.Step{
-				{
-					ID:   2,
-					Kind: planfmt.KindDecorator,
-					Op:   "shell",
-					Args: []planfmt.Arg{
-						{Key: "cmd", Val: planfmt.Value{Kind: planfmt.ValueString, Str: "echo task1"}},
-						{Key: "timeout", Val: planfmt.Value{Kind: planfmt.ValueInt, Int: 30}},
-					},
-				},
-				{
-					ID:   3,
-					Kind: planfmt.KindDecorator,
-					Op:   "shell",
-					Args: []planfmt.Arg{
-						{Key: "cmd", Val: planfmt.Value{Kind: planfmt.ValueString, Str: "echo task2"}},
+		Steps: []planfmt.Step{
+			{
+				ID: 1,
+				Commands: []planfmt.Command{
+					{
+						Decorator: "@parallel",
+						Args: []planfmt.Arg{
+							{Key: "max_concurrent", Val: planfmt.Value{Kind: planfmt.ValueInt, Int: 4}},
+						},
+						Block: []planfmt.Step{
+							{
+								ID: 2,
+								Commands: []planfmt.Command{
+									{
+										Decorator: "@shell",
+										Args: []planfmt.Arg{
+											{Key: "cmd", Val: planfmt.Value{Kind: planfmt.ValueString, Str: "echo task1"}},
+											{Key: "timeout", Val: planfmt.Value{Kind: planfmt.ValueInt, Int: 30}},
+										},
+									},
+								},
+							},
+							{
+								ID: 3,
+								Commands: []planfmt.Command{
+									{
+										Decorator: "@shell",
+										Args: []planfmt.Arg{
+											{Key: "cmd", Val: planfmt.Value{Kind: planfmt.ValueString, Str: "echo task2"}},
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
## Summary

Refactor plan format to correctly represent steps with operator-chained commands.

## Problem

Current format cannot distinguish:
- `echo "A" && echo "B"` (ONE step, bash controls `&&`)
- `echo "A"\necho "B"` (TWO steps, Opal controls)

This breaks contract verification for operator semantics.

## Solution

New plan structure:
- `Plan.Steps []Step` instead of `Plan.Root *Step`
- `Step.Commands []Command` instead of single Op
- `Command` captures decorator + operator chaining
- Made `canonicalize()` internal (only called by writer)

## Changes

- Breaking change to v1.0 format (pre-release, no backward compat needed)
- Updated all serialization/deserialization code
- Updated all 8 test files
- All tests passing (100%)
- Fuzz tested: 1.7M executions, no crashes

## Why

Enables correct contract verification - different operator semantics must produce different plan hashes.