### PR TITLE
refactor: move tree display to formatter package

### DIFF
--- a/.nix/package.nix
+++ b/.nix/package.nix
@@ -23,7 +23,7 @@ pkgs.buildGoModule rec {
   };
 
   # Vendor hash for CLI module dependencies  
-  vendorHash = "sha256-tqfunrFsoNiMn26phmDyug0n6m2EWbJ7w7xPolHojp4=";
+  vendorHash = "sha256-n1clNRC0rdu9ouVnM8QaLafvMXh2Dz7pHm/jQn73l+Y=";
 
   # Build with version info
   ldflags = [

--- a/cli/colors.go
+++ b/cli/colors.go
@@ -2,25 +2,25 @@ package main
 
 import (
 	"os"
+
+	"github.com/aledsdavies/opal/core/planfmt/formatter"
 )
 
-// ANSI color codes
+// Re-export color constants from formatter package for convenience
 const (
-	ColorReset  = "\033[0m"
-	ColorRed    = "\033[31m"
-	ColorGreen  = "\033[32m"
-	ColorYellow = "\033[33m"
-	ColorBlue   = "\033[34m"
-	ColorCyan   = "\033[36m"
-	ColorGray   = "\033[90m"
+	ColorReset  = formatter.ColorReset
+	ColorRed    = formatter.ColorRed
+	ColorGreen  = formatter.ColorGreen
+	ColorYellow = formatter.ColorYellow
+	ColorBlue   = formatter.ColorBlue
+	ColorCyan   = formatter.ColorCyan
+	ColorGray   = formatter.ColorGray
 )
 
 // Colorize wraps text in ANSI color codes if color is enabled
+// This is a convenience wrapper around formatter.Colorize
 func Colorize(text, color string, useColor bool) string {
-	if !useColor {
-		return text
-	}
-	return color + text + ColorReset
+	return formatter.Colorize(text, color, useColor)
 }
 
 // ShouldUseColor determines if color output should be used

--- a/cli/display.go
+++ b/cli/display.go
@@ -1,79 +1,14 @@
 package main
 
 import (
-	"fmt"
 	"io"
-	"strings"
 
 	"github.com/aledsdavies/opal/core/planfmt"
+	"github.com/aledsdavies/opal/core/planfmt/formatter"
 )
 
 // DisplayPlan renders a plan as a tree structure
+// This is a thin wrapper around formatter.FormatTree for backwards compatibility
 func DisplayPlan(w io.Writer, plan *planfmt.Plan, useColor bool) {
-	// Print target name
-	_, _ = fmt.Fprintf(w, "%s:\n", plan.Target)
-
-	// Handle empty plan
-	if len(plan.Steps) == 0 {
-		_, _ = fmt.Fprintf(w, "(no steps)\n")
-		return
-	}
-
-	// Render each step
-	for i, step := range plan.Steps {
-		isLast := i == len(plan.Steps)-1
-		renderStep(w, step, isLast, useColor)
-	}
-}
-
-// renderStep renders a single step with tree characters
-func renderStep(w io.Writer, step planfmt.Step, isLast bool, useColor bool) {
-	// Choose tree character
-	var prefix string
-	if isLast {
-		prefix = "└─ "
-	} else {
-		prefix = "├─ "
-	}
-
-	// For steps with operators, show decorator once then commands with operators
-	if len(step.Commands) > 1 {
-		// Get decorator from first command (all should be same in a step)
-		decorator := Colorize(step.Commands[0].Decorator, ColorBlue, useColor)
-
-		// Build command parts with operators
-		var cmdParts []string
-		for i, cmd := range step.Commands {
-			cmdParts = append(cmdParts, getCommandString(cmd))
-			if i < len(step.Commands)-1 {
-				cmdParts = append(cmdParts, cmd.Operator)
-			}
-		}
-
-		fullCommand := decorator + " " + strings.Join(cmdParts, " ")
-		_, _ = fmt.Fprintf(w, "%s%s\n", prefix, fullCommand)
-		return
-	}
-
-	// Single command: show decorator + command
-	cmd := step.Commands[0]
-	decorator := Colorize(cmd.Decorator, ColorBlue, useColor)
-	commandStr := getCommandString(cmd)
-	_, _ = fmt.Fprintf(w, "%s%s %s\n", prefix, decorator, commandStr)
-}
-
-// getCommandString extracts the command string from a Command
-func getCommandString(cmd planfmt.Command) string {
-	// For @shell decorator, look for "command" arg
-	for _, arg := range cmd.Args {
-		if arg.Key == "command" && arg.Val.Kind == planfmt.ValueString {
-			return arg.Val.Str
-		}
-	}
-	// Fallback: show all args
-	var parts []string
-	for _, arg := range cmd.Args {
-		parts = append(parts, fmt.Sprintf("%s=%v", arg.Key, arg.Val.Str))
-	}
-	return strings.Join(parts, " ")
+	formatter.FormatTree(w, plan, useColor)
 }

--- a/cli/test.opl
+++ b/cli/test.opl
@@ -1,1 +1,1 @@
-test-cmd: echo 'hello from stdin'
+fun test = echo "hello world"

--- a/core/planfmt/formatter/tree.go
+++ b/core/planfmt/formatter/tree.go
@@ -1,0 +1,99 @@
+package formatter
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/aledsdavies/opal/core/planfmt"
+)
+
+// ANSI color codes
+const (
+	ColorReset  = "\033[0m"
+	ColorRed    = "\033[31m"
+	ColorGreen  = "\033[32m"
+	ColorYellow = "\033[33m"
+	ColorBlue   = "\033[34m"
+	ColorCyan   = "\033[36m"
+	ColorGray   = "\033[90m"
+)
+
+// Colorize wraps text in ANSI color codes if color is enabled
+func Colorize(text, color string, useColor bool) string {
+	if !useColor {
+		return text
+	}
+	return color + text + ColorReset
+}
+
+// FormatTree renders a plan as a tree structure to the given writer.
+// This is used for --dry-run output to show the execution plan visually.
+func FormatTree(w io.Writer, plan *planfmt.Plan, useColor bool) {
+	// Print target name
+	_, _ = fmt.Fprintf(w, "%s:\n", plan.Target)
+
+	// Handle empty plan
+	if len(plan.Steps) == 0 {
+		_, _ = fmt.Fprintf(w, "(no steps)\n")
+		return
+	}
+
+	// Render each step
+	for i, step := range plan.Steps {
+		isLast := i == len(plan.Steps)-1
+		renderTreeStep(w, step, isLast, useColor)
+	}
+}
+
+// renderTreeStep renders a single step with tree characters
+func renderTreeStep(w io.Writer, step planfmt.Step, isLast bool, useColor bool) {
+	// Choose tree character
+	var prefix string
+	if isLast {
+		prefix = "└─ "
+	} else {
+		prefix = "├─ "
+	}
+
+	// For steps with operators, show decorator once then commands with operators
+	if len(step.Commands) > 1 {
+		// Get decorator from first command (all should be same in a step)
+		decorator := Colorize(step.Commands[0].Decorator, ColorBlue, useColor)
+
+		// Build command parts with operators
+		var cmdParts []string
+		for i, cmd := range step.Commands {
+			cmdParts = append(cmdParts, getTreeCommandString(cmd))
+			if i < len(step.Commands)-1 {
+				cmdParts = append(cmdParts, cmd.Operator)
+			}
+		}
+
+		fullCommand := decorator + " " + strings.Join(cmdParts, " ")
+		_, _ = fmt.Fprintf(w, "%s%s\n", prefix, fullCommand)
+		return
+	}
+
+	// Single command: show decorator + command
+	cmd := step.Commands[0]
+	decorator := Colorize(cmd.Decorator, ColorBlue, useColor)
+	commandStr := getTreeCommandString(cmd)
+	_, _ = fmt.Fprintf(w, "%s%s %s\n", prefix, decorator, commandStr)
+}
+
+// getTreeCommandString extracts the command string from a Command for tree display
+func getTreeCommandString(cmd planfmt.Command) string {
+	// For @shell decorator, look for "command" arg
+	for _, arg := range cmd.Args {
+		if arg.Key == "command" && arg.Val.Kind == planfmt.ValueString {
+			return arg.Val.Str
+		}
+	}
+	// Fallback: show all args
+	var parts []string
+	for _, arg := range cmd.Args {
+		parts = append(parts, fmt.Sprintf("%s=%v", arg.Key, arg.Val.Str))
+	}
+	return strings.Join(parts, " ")
+}

--- a/core/planfmt/formatter/tree_test.go
+++ b/core/planfmt/formatter/tree_test.go
@@ -1,0 +1,222 @@
+package formatter
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/aledsdavies/opal/core/planfmt"
+)
+
+func TestFormatTree_EmptyPlan(t *testing.T) {
+	plan := &planfmt.Plan{
+		Target: "test",
+		Steps:  []planfmt.Step{},
+	}
+
+	var buf bytes.Buffer
+	FormatTree(&buf, plan, false)
+
+	expected := "test:\n(no steps)\n"
+	if buf.String() != expected {
+		t.Errorf("Expected:\n%s\nGot:\n%s", expected, buf.String())
+	}
+}
+
+func TestFormatTree_SingleStep(t *testing.T) {
+	plan := &planfmt.Plan{
+		Target: "deploy",
+		Steps: []planfmt.Step{
+			{
+				ID: 1,
+				Commands: []planfmt.Command{
+					{
+						Decorator: "shell",
+						Args: []planfmt.Arg{
+							{Key: "command", Val: planfmt.Value{Kind: planfmt.ValueString, Str: "echo hello"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	FormatTree(&buf, plan, false)
+
+	output := buf.String()
+	if !strings.Contains(output, "deploy:") {
+		t.Error("Expected target name 'deploy:'")
+	}
+	if !strings.Contains(output, "└─ shell echo hello") {
+		t.Errorf("Expected tree output with shell command, got:\n%s", output)
+	}
+}
+
+func TestFormatTree_MultipleSteps(t *testing.T) {
+	plan := &planfmt.Plan{
+		Target: "build",
+		Steps: []planfmt.Step{
+			{
+				ID: 1,
+				Commands: []planfmt.Command{
+					{
+						Decorator: "shell",
+						Args: []planfmt.Arg{
+							{Key: "command", Val: planfmt.Value{Kind: planfmt.ValueString, Str: "go build"}},
+						},
+					},
+				},
+			},
+			{
+				ID: 2,
+				Commands: []planfmt.Command{
+					{
+						Decorator: "shell",
+						Args: []planfmt.Arg{
+							{Key: "command", Val: planfmt.Value{Kind: planfmt.ValueString, Str: "go test"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	FormatTree(&buf, plan, false)
+
+	output := buf.String()
+	if !strings.Contains(output, "├─ shell go build") {
+		t.Errorf("Expected first step with ├─, got:\n%s", output)
+	}
+	if !strings.Contains(output, "└─ shell go test") {
+		t.Errorf("Expected last step with └─, got:\n%s", output)
+	}
+}
+
+func TestFormatTree_WithOperators(t *testing.T) {
+	plan := &planfmt.Plan{
+		Target: "test",
+		Steps: []planfmt.Step{
+			{
+				ID: 1,
+				Commands: []planfmt.Command{
+					{
+						Decorator: "shell",
+						Args: []planfmt.Arg{
+							{Key: "command", Val: planfmt.Value{Kind: planfmt.ValueString, Str: "go build"}},
+						},
+						Operator: "&&",
+					},
+					{
+						Decorator: "shell",
+						Args: []planfmt.Arg{
+							{Key: "command", Val: planfmt.Value{Kind: planfmt.ValueString, Str: "go test"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	FormatTree(&buf, plan, false)
+
+	output := buf.String()
+	if !strings.Contains(output, "shell go build && go test") {
+		t.Errorf("Expected operator chain, got:\n%s", output)
+	}
+}
+
+func TestFormatTree_WithColor(t *testing.T) {
+	plan := &planfmt.Plan{
+		Target: "test",
+		Steps: []planfmt.Step{
+			{
+				ID: 1,
+				Commands: []planfmt.Command{
+					{
+						Decorator: "shell",
+						Args: []planfmt.Arg{
+							{Key: "command", Val: planfmt.Value{Kind: planfmt.ValueString, Str: "echo hello"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	FormatTree(&buf, plan, true)
+
+	output := buf.String()
+	// Should contain ANSI color codes
+	if !strings.Contains(output, ColorBlue) {
+		t.Error("Expected color codes in output")
+	}
+	if !strings.Contains(output, ColorReset) {
+		t.Error("Expected color reset in output")
+	}
+}
+
+func TestFormatTree_WithoutColor(t *testing.T) {
+	plan := &planfmt.Plan{
+		Target: "test",
+		Steps: []planfmt.Step{
+			{
+				ID: 1,
+				Commands: []planfmt.Command{
+					{
+						Decorator: "shell",
+						Args: []planfmt.Arg{
+							{Key: "command", Val: planfmt.Value{Kind: planfmt.ValueString, Str: "echo hello"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	FormatTree(&buf, plan, false)
+
+	output := buf.String()
+	// Should NOT contain ANSI color codes
+	if strings.Contains(output, ColorBlue) {
+		t.Error("Expected no color codes in output")
+	}
+}
+
+func TestColorize(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		color    string
+		useColor bool
+		want     string
+	}{
+		{
+			name:     "with color enabled",
+			text:     "hello",
+			color:    ColorBlue,
+			useColor: true,
+			want:     ColorBlue + "hello" + ColorReset,
+		},
+		{
+			name:     "with color disabled",
+			text:     "hello",
+			color:    ColorBlue,
+			useColor: false,
+			want:     "hello",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Colorize(tt.text, tt.color, tt.useColor)
+			if got != tt.want {
+				t.Errorf("Colorize() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Moved tree rendering from CLI to core/planfmt/formatter so other tools can use it. Created formatter/tree.go with FormatTree() and moved the color utilities there too. CLI now just calls the formatter instead of doing the rendering itself. Added tests for all the tree display cases. All tests pass, CLI output looks the same.