### PR TITLE
feat: add shell operator support

### DIFF
--- a/.nix/package.nix
+++ b/.nix/package.nix
@@ -23,7 +23,7 @@ pkgs.buildGoModule rec {
   };
 
   # Vendor hash for CLI module dependencies  
-  vendorHash = "sha256-eMXjFEA0UMS7XM1VJbOo/L1eI7/prdtzVZWC93VMRaA=";
+  vendorHash = "sha256-bu62sHaqHbxagdamccIRfYhicXibi9nxwd7bxd4ErFA=";
 
   # Build with version info
   ldflags = [

--- a/examples/operators.opl
+++ b/examples/operators.opl
@@ -1,0 +1,63 @@
+# Operator Examples
+# Demonstrates shell operator support in Opal
+
+# Semicolon (;) - Always execute next command
+fun demo_semicolon {
+    echo "Command 1"; echo "Command 2"; echo "Command 3"
+    echo "All three commands run regardless of exit codes"
+}
+
+# AND (&&) - Execute next only if previous succeeded
+fun demo_and {
+    echo "Building..." && echo "Build succeeded!" && echo "Ready to deploy"
+    echo "All commands run only if previous ones succeed"
+}
+
+fun demo_and_fail {
+    echo "Starting..."
+    false && echo "This won't run because previous command failed"
+    echo "But this runs (newline = new step)"
+}
+
+# OR (||) - Execute next only if previous failed
+fun demo_or {
+    echo "Trying primary..." || echo "Fallback executed"
+    echo "Primary succeeded, so fallback was skipped"
+}
+
+fun demo_or_fallback {
+    false || echo "Primary failed, running fallback"
+    echo "Fallback ran successfully"
+}
+
+# Mixed operators - Demonstrates precedence
+fun demo_mixed {
+    echo "Test 1" && echo "Success" || echo "Fallback"
+    echo "Both Test 1 and Success ran, Fallback skipped"
+}
+
+fun demo_mixed_fallback {
+    false && echo "Won't run" || echo "Fallback runs"
+    echo "First command failed, AND skipped second, OR ran fallback"
+}
+
+# Real-world examples
+fun build_and_test {
+    echo "Building project..." &&
+    echo "Running tests..." &&
+    echo "All tests passed!" ||
+    echo "Build or tests failed"
+}
+
+fun deploy_with_fallback {
+    echo "Deploying to production..." ||
+    echo "Production deploy failed, trying staging..." ||
+    echo "All deploys failed!"
+}
+
+# Operators work with all decorators
+fun retry_with_operators {
+    @retry(times=3) {
+        curl https://api.example.com && echo "API call succeeded" || echo "API call failed after retries"
+    }
+}

--- a/runtime/parser/parser.go
+++ b/runtime/parser/parser.go
@@ -1321,13 +1321,13 @@ func (p *parser) shellArg() {
 func (p *parser) isShellOperator() bool {
 	return p.at(lexer.AND_AND) || // &&
 		p.at(lexer.OR_OR) || // ||
-		p.at(lexer.PIPE) // |
+		p.at(lexer.PIPE) || // |
+		p.at(lexer.SEMICOLON) // ;
 }
 
 // isStatementBoundary checks if current token ends a statement
 func (p *parser) isStatementBoundary() bool {
 	return p.at(lexer.NEWLINE) ||
-		p.at(lexer.SEMICOLON) ||
 		p.at(lexer.RBRACE) ||
 		p.at(lexer.EOF) ||
 		p.at(lexer.ELSE) // Stop at else (for when arms and if/else)


### PR DESCRIPTION
## Summary

Add support for shell operators (&&, ||, ;) with bash semantics.

Opal now controls operator execution instead of passing commands to bash. This gives consistent behavior across platforms and makes operators work with all decorators automatically.

## Changes

Parser: Moved semicolon from statement boundary to shell operator
Executor: Added operator chaining logic with skip/execute semantics
Tests: Added unit tests and integration tests covering all operators
Docs: Updated ARCHITECTURE.md to reflect Opal-controlled operators
Examples: Added operators.opl showing real-world usage

## Why

Users need operators for common patterns like `build && test` and `cmd || fallback`. By implementing bash semantics in Go, we get cross-platform consistency and operators work with @retry, @timeout, etc. for free.

## Deferred

Pipe (|) operator needs stdout→stdin wiring between commands, saved for later.