### PR TITLE
feat: implement @shell as multi-role decorator (Exec + Endpoint)

### DIFF
--- a/core/decorator/exec.go
+++ b/core/decorator/exec.go
@@ -3,7 +3,6 @@ package decorator
 import (
 	"context"
 	"io"
-	"time"
 )
 
 // Exec is the interface for decorators that wrap execution.
@@ -21,14 +20,12 @@ type ExecNode interface {
 
 // ExecContext provides the execution context for command execution.
 type ExecContext struct {
+	// Context is the parent context for cancellation and deadlines
+	// Decorators should pass this to Session.Run() and other operations
+	Context context.Context
+
 	// Session is the ambient execution context (env, cwd, transport)
 	Session Session
-
-	// Deadline is the absolute time when execution must complete
-	Deadline time.Time
-
-	// Cancel cancels the execution
-	Cancel context.CancelFunc
 
 	// Stdin provides input data for piped commands (nil if not piped)
 	// Used for pipe operators: cmd1 | cmd2

--- a/runtime/parser/parser_test.go
+++ b/runtime/parser/parser_test.go
@@ -621,75 +621,10 @@ func TestNamespacedDecoratorParsing(t *testing.T) {
 	})
 }
 
-// TestEnumParameterValidation tests that enum parameters are validated
-func TestEnumParameterValidation(t *testing.T) {
-	tests := []struct {
-		name        string
-		input       string
-		expectError bool
-		errorMsg    string
-	}{
-		{
-			name:        "valid enum value: none",
-			input:       `@shell("echo test", scrub="none")`,
-			expectError: false,
-		},
-		{
-			name:        "valid enum value: stdin",
-			input:       `@shell("echo test", scrub="stdin")`,
-			expectError: false,
-		},
-		{
-			name:        "valid enum value: stdout",
-			input:       `@shell("echo test", scrub="stdout")`,
-			expectError: false,
-		},
-		{
-			name:        "valid enum value: both",
-			input:       `@shell("echo test", scrub="both")`,
-			expectError: false,
-		},
-		{
-			name:        "invalid enum value",
-			input:       `@shell("echo test", scrub="invalid")`,
-			expectError: true,
-			errorMsg:    "invalid value",
-		},
-		{
-			name:        "wrong type for enum",
-			input:       `@shell("echo test", scrub=true)`,
-			expectError: true,
-			errorMsg:    "expects",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tree := Parse([]byte(tt.input))
-
-			if tt.expectError {
-				if len(tree.Errors) == 0 {
-					t.Errorf("expected parse error but got none")
-				} else {
-					found := false
-					for _, err := range tree.Errors {
-						if strings.Contains(err.Message, tt.errorMsg) {
-							found = true
-							break
-						}
-					}
-					if !found {
-						t.Errorf("expected error containing %q, got: %v", tt.errorMsg, tree.Errors)
-					}
-				}
-			} else {
-				if len(tree.Errors) > 0 {
-					t.Errorf("unexpected parse errors: %v", tree.Errors)
-				}
-			}
-		})
-	}
-}
+// TestEnumParameterValidation - REMOVED
+// The old @shell decorator had a 'scrub' enum parameter for testing enum validation.
+// The new @shell decorator doesn't have this parameter.
+// Enum validation is tested in core/types/schema_validation_test.go instead.
 
 // TestValueDecoratorRejectsBlock verifies value decorators cannot take blocks
 func TestValueDecoratorRejectsBlock(t *testing.T) {


### PR DESCRIPTION
## feat: implement @shell as multi-role decorator (Exec + Endpoint)

Migrated @shell to the new decorator architecture. It now implements both Exec (for command execution) and Endpoint (for file I/O) interfaces.

**What changed:**
- @shell can execute commands: `@shell("echo hello")`
- @shell can handle file I/O: `echo "data" > @shell("file.txt")`
- Added dual registration (new decorator registry + old SDK registry for backward compat)
- Fixed executor to accept ExitCanceled = -1 exit code
- Context cancellation now propagates correctly through execution

**Why dual registration:**
During migration, redirect targets still use the old SDK registry. Created shellSDKAdapter to bridge Endpoint interface to old SinkProvider. Once all decorators migrate, we can remove the old registry.

**Architecture:**
ShellDecorator stores params in a field. When used as endpoint, create instance with params then call Open(). Avoids circular dependencies between core and runtime modules.