### PR TITLE
feat: add enum, object, array schema types

### DIFF
--- a/.nix/package.nix
+++ b/.nix/package.nix
@@ -23,7 +23,7 @@ pkgs.buildGoModule rec {
   };
 
   # Vendor hash for CLI module dependencies  
-  vendorHash = "sha256-8blNPZa1RA80fSBfxeULzSGhJI7WOUiFfqzqufjk8H8=";
+  vendorHash = "sha256-WuOAoTw+OsYrlIjrqAW3rNLi38kujGF5cb7BWhZA2yc=";
 
   # Build with version info
   ldflags = [


### PR DESCRIPTION
Phase 1 of type system work. Added three new schema types for complex parameters:

- EnumSchema for allowed values with deprecation warnings
- ObjectSchema for structured data with required fields (closed by default)
- ArraySchema for lists with element constraints

Also added TypeEnum constant and MinLength/MaxLength constraints. All tests pass, no breaking changes.