### PR TITLE
feat: add plan structures for secret authority

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,6 +60,7 @@ linters:
         - (*io.Closer).Close
         - (net/http.(*Response)).Body.Close
         - (fmt.*).Print*
+        - (hash.Hash).Write  # hash.Hash.Write never returns an error
     revive:
       # Keep this small; add rules as the team agrees
       rules:

--- a/core/planfmt/fuzz_test.go
+++ b/core/planfmt/fuzz_test.go
@@ -54,6 +54,7 @@ func FuzzReadPlan(f *testing.F) {
 
 // addSeedCorpus adds valid plans to the fuzz corpus
 func addSeedCorpus(f *testing.F) {
+	f.Helper()
 	seeds := []struct {
 		name string
 		plan *planfmt.Plan

--- a/core/planfmt/plan_test.go
+++ b/core/planfmt/plan_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/aledsdavies/opal/core/planfmt"
+	"github.com/google/go-cmp/cmp"
 )
 
 // TestPlanValidation verifies plan invariants are checked
@@ -203,5 +204,169 @@ func TestPlanDigestDifferentPlans(t *testing.T) {
 
 	if digest1 == digest2 {
 		t.Errorf("Different plans produced same digest: %s", digest1)
+	}
+}
+
+// ============================================================================
+// Phase 1: Site-Based Secret Authority - Plan Data Structures
+// ============================================================================
+
+// TestPlanSecretUses_RecordsUseSites verifies that SecretUses can be recorded
+func TestPlanSecretUses_RecordsUseSites(t *testing.T) {
+	plan := &planfmt.Plan{}
+
+	use := planfmt.SecretUse{
+		DisplayID: "opal:v:3J98t56A",
+		SiteID:    "Xj9K...",
+		Site:      "root/retry[0]/params/apiKey",
+	}
+
+	err := plan.AddSecretUse(use)
+	if err != nil {
+		t.Fatalf("AddSecretUse() error = %v", err)
+	}
+
+	if len(plan.SecretUses) != 1 {
+		t.Errorf("SecretUses length = %d, want 1", len(plan.SecretUses))
+	}
+
+	got := plan.SecretUses[0]
+	if diff := cmp.Diff(use, got); diff != "" {
+		t.Errorf("SecretUse mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestPlanHash_IncludesSecretUses verifies plan hash includes SecretUses
+func TestPlanHash_IncludesSecretUses(t *testing.T) {
+	plan1 := planfmt.NewPlan()
+	plan1.Target = "test"
+	plan1.AddSecretUse(planfmt.SecretUse{
+		DisplayID: "opal:v:AAA",
+		SiteID:    "site-X",
+		Site:      "root/retry[0]/params/apiKey",
+	})
+	plan1.Freeze()
+
+	plan2 := planfmt.NewPlan()
+	plan2.Target = "test"
+	plan2.AddSecretUse(planfmt.SecretUse{
+		DisplayID: "opal:v:BBB",
+		SiteID:    "site-Y",
+		Site:      "root/timeout[0]/params/duration",
+	})
+	plan2.Freeze()
+
+	if plan1.Hash == plan2.Hash {
+		t.Errorf("Different SecretUses produced same hash: %s", plan1.Hash)
+	}
+
+	if plan1.Hash == "" {
+		t.Error("plan1.Hash is empty after Freeze()")
+	}
+	if plan2.Hash == "" {
+		t.Error("plan2.Hash is empty after Freeze()")
+	}
+}
+
+// TestPlanFreeze_PreventsMutation verifies frozen plans reject mutations
+func TestPlanFreeze_PreventsMutation(t *testing.T) {
+	plan := planfmt.NewPlan()
+	plan.Freeze()
+
+	err := plan.AddSecretUse(planfmt.SecretUse{
+		DisplayID: "opal:v:ATTACK",
+		SiteID:    "malicious",
+		Site:      "root/evil[0]/params/stolen",
+	})
+
+	if err == nil {
+		t.Error("AddSecretUse() on frozen plan should return error, got nil")
+	}
+
+	if !contains(err.Error(), "frozen") {
+		t.Errorf("AddSecretUse() error = %v, want error containing 'frozen'", err)
+	}
+}
+
+// TestPlanHash_DetectsTampering verifies hash detects tampering
+func TestPlanHash_DetectsTampering(t *testing.T) {
+	plan := planfmt.NewPlan()
+	plan.Target = "test"
+	plan.AddSecretUse(planfmt.SecretUse{
+		DisplayID: "opal:v:LEGIT",
+		SiteID:    "site-1",
+		Site:      "root/retry[0]/params/apiKey",
+	})
+	plan.Freeze()
+
+	originalHash := plan.Hash
+
+	// Simulate attacker tampering with frozen plan (bypassing AddSecretUse)
+	plan.SecretUses = append(plan.SecretUses, planfmt.SecretUse{
+		DisplayID: "opal:v:ATTACK",
+		SiteID:    "malicious-site",
+		Site:      "root/evil[0]/params/stolen",
+	})
+
+	// Recompute hash to detect tampering
+	currentHash := plan.ComputeHash()
+
+	if originalHash == currentHash {
+		t.Error("Hash did not change after tampering with SecretUses")
+	}
+}
+
+// TestPlanSalt_IsRandom verifies each plan gets unique random salt
+func TestPlanSalt_IsRandom(t *testing.T) {
+	plan1 := planfmt.NewPlan()
+	plan2 := planfmt.NewPlan()
+
+	if len(plan1.PlanSalt) != 32 {
+		t.Errorf("plan1.PlanSalt length = %d, want 32 bytes", len(plan1.PlanSalt))
+	}
+
+	if len(plan2.PlanSalt) != 32 {
+		t.Errorf("plan2.PlanSalt length = %d, want 32 bytes", len(plan2.PlanSalt))
+	}
+
+	if cmp.Equal(plan1.PlanSalt, plan2.PlanSalt) {
+		t.Error("Two plans have identical PlanSalt (should be random)")
+	}
+}
+
+// TestPlanHash_ChangesWhenSecretUsesChange verifies hash is sensitive to SecretUses
+func TestPlanHash_ChangesWhenSecretUsesChange(t *testing.T) {
+	plan := planfmt.NewPlan()
+	plan.Target = "test"
+
+	// Hash with no SecretUses
+	hash1 := plan.ComputeHash()
+
+	// Add one SecretUse
+	plan.AddSecretUse(planfmt.SecretUse{
+		DisplayID: "opal:v:AAA",
+		SiteID:    "site-1",
+		Site:      "root/retry[0]/params/apiKey",
+	})
+	hash2 := plan.ComputeHash()
+
+	// Add another SecretUse
+	plan.AddSecretUse(planfmt.SecretUse{
+		DisplayID: "opal:v:BBB",
+		SiteID:    "site-2",
+		Site:      "root/timeout[0]/params/duration",
+	})
+	hash3 := plan.ComputeHash()
+
+	if hash1 == hash2 {
+		t.Error("Hash did not change after adding first SecretUse")
+	}
+
+	if hash2 == hash3 {
+		t.Error("Hash did not change after adding second SecretUse")
+	}
+
+	if hash1 == hash3 {
+		t.Error("Hash with 0 and 2 SecretUses should differ")
 	}
 }

--- a/core/planfmt/roundtrip_test.go
+++ b/core/planfmt/roundtrip_test.go
@@ -214,7 +214,7 @@ func TestRoundTripPreservesSemantics(t *testing.T) {
 	}
 
 	// Compare semantics (use cmp for deep equality, ignore unexported fields)
-	opts := cmpopts.IgnoreUnexported(planfmt.PlanHeader{})
+	opts := cmpopts.IgnoreUnexported(planfmt.PlanHeader{}, planfmt.Plan{})
 	if diff := cmp.Diff(original, decoded, opts); diff != "" {
 		t.Errorf("Semantic mismatch after round-trip (-original +decoded):\n%s", diff)
 	}

--- a/core/planfmt/tree_roundtrip_test.go
+++ b/core/planfmt/tree_roundtrip_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aledsdavies/opal/core/planfmt"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestTreeRoundTrip(t *testing.T) {
@@ -212,8 +213,9 @@ func TestTreeRoundTrip(t *testing.T) {
 				t.Errorf("bytes mismatch (not lossless)\n  first:  %d bytes\n  second: %d bytes", len(bytes1), len(bytes2))
 			}
 
-			// Structure must match (deep equality)
-			if diff := cmp.Diff(tt.plan, plan2); diff != "" {
+			// Structure must match (deep equality, ignore unexported fields)
+			opts := cmpopts.IgnoreUnexported(planfmt.Plan{}, planfmt.PlanHeader{})
+			if diff := cmp.Diff(tt.plan, plan2, opts); diff != "" {
 				t.Errorf("plan mismatch (-want +got):\n%s", diff)
 			}
 

--- a/runtime/parser/controlflow_test.go
+++ b/runtime/parser/controlflow_test.go
@@ -528,10 +528,12 @@ func TestForLoop(t *testing.T) {
 				{EventToken, 8},     // echo
 				{EventClose, 9},     // ShellArg
 				{EventOpen, 9},      // ShellArg
+				{EventOpen, 18},     // Decorator (@var.item)
 				{EventToken, 9},     // @
 				{EventToken, 10},    // var
 				{EventToken, 11},    // .
 				{EventToken, 12},    // item
+				{EventClose, 18},    // Decorator
 				{EventClose, 9},     // ShellArg
 				{EventClose, 8},     // ShellCommand
 				{EventStepExit, 0},  // Step boundary

--- a/runtime/parser/parser.go
+++ b/runtime/parser/parser.go
@@ -1340,6 +1340,9 @@ func (p *parser) shellArg() {
 	if p.at(lexer.STRING) && p.stringNeedsInterpolation() {
 		// Parse string with interpolation
 		p.stringLiteral()
+	} else if p.at(lexer.AT) {
+		// Decorator: @var.HOME, @env.PATH, etc.
+		p.decorator()
 	} else {
 		// Consume first token (guaranteed to exist due to precondition)
 		if p.config.debug >= DebugDetailed {

--- a/runtime/parser/parser_test.go
+++ b/runtime/parser/parser_test.go
@@ -516,8 +516,21 @@ func TestRedirectOperatorValidation(t *testing.T) {
 		expectedError *ParseError
 	}{
 		{
-			name:  "redirect to decorator without redirect support",
+			name:  "redirect to decorator without block - syntax error first",
 			input: `echo "test" > @timeout(5s)`,
+			expectedError: &ParseError{
+				Position:   lexer.Position{Line: 1, Column: 27, Offset: 26},
+				Message:    "@timeout requires a block",
+				Context:    "decorator block",
+				Got:        lexer.EOF,
+				Suggestion: "Add a block: @timeout(...) { ... }",
+				Example:    "",
+				Note:       "",
+			},
+		},
+		{
+			name:  "redirect to decorator with block but no redirect support",
+			input: `echo "test" > @timeout(5s) { echo "inner" }`,
 			expectedError: &ParseError{
 				Position:   lexer.Position{Line: 1, Column: 13, Offset: 12},
 				Message:    "@timeout does not support redirection",


### PR DESCRIPTION
Need to track which decorators can unwrap which secrets. Added SecretUse tracking to Plan so the planner can record authorizations and the executor can enforce them.

Plan.SecretUses[] maps DisplayID to SiteID (HMAC of AST path). Each entry grants one decorator parameter permission to unwrap one secret. Parent and child decorators cannot unwrap - only the declared site.

Plan.Hash includes SecretUses to detect tampering. Plan.frozen prevents adding unauthorized sites after planning. Plan.PlanSalt provides entropy for deterministic DisplayID generation.

Added 6 tests for recording, hash integrity, and tampering detection. Fixed existing tests to ignore the unexported frozen field.

This is Phase 1 of 5. Next up: decorator parameter classes for plan-time validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plans can be frozen to guarantee immutability after approval.
  * Plan integrity verification via cryptographic hashing with per‑plan salt.
  * Site‑based secret authorization: plans record authorized use sites and carry secret placeholders for runtime values.
  * Decorators in shell arguments supported; runtime‑decorated values become placeholders in plans.

* **Documentation**
  * Architecture docs updated with site‑based secret model, transport rules, and plan verification guidance.

* **Tests**
  * Added tests covering hashing, freeze behavior, secret‑use recording, and decorator interpolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->