### PR TITLE
chore: change CodeRabbit profile from assertive to chill

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,12 +1,12 @@
 # CodeRabbit configuration
 # Docs: https://docs.coderabbit.ai/
 
-# Tone: Direct and technical, focus on bugs not style
-tone_instructions: "Be direct and technical. Focus only on bugs, security issues, logic errors, and correctness problems. Skip style suggestions - we have gofumpt and golangci-lint for that."
+# Tone: Calm and helpful, focus on bugs not style
+tone_instructions: "Be calm, helpful, and constructive. Focus only on bugs, security issues, logic errors, and correctness problems. Skip style suggestions - we have gofumpt and golangci-lint for that. When suggesting improvements, explain the reasoning gently."
 
 reviews:
-  # Assertive profile for more thorough issue detection
-  profile: "assertive"
+  # Chill profile for calmer, less aggressive reviews
+  profile: "chill"
   
   auto_review:
     enabled: true


### PR DESCRIPTION
## Summary
- Switch CodeRabbit review profile from "assertive" to "chill" for calmer, less aggressive code reviews
- Update tone instructions to be more helpful and constructive

## Changes
- Profile: `assertive` → `chill`
- Tone: "direct and technical" → "calm, helpful, and constructive"
- Added instruction to explain reasoning gently when suggesting improvements

## Why
The assertive profile was too aggressive in its review comments. The chill profile maintains focus on bugs, security, and correctness while being more constructive in tone.