### PR TITLE
fix: replace unsafe type assertions with checked assertions in var decorator

### DIFF
--- a/runtime/decorators/var.go
+++ b/runtime/decorators/var.go
@@ -75,7 +75,15 @@ func (d *VarDecorator) Resolve(ctx decorator.ValueEvalContext, calls ...decorato
 
 		// Check for error
 		if !lookupResults[1].IsNil() {
-			err := lookupResults[1].Interface().(error)
+			err, ok := lookupResults[1].Interface().(error)
+			if !ok {
+				results[i] = decorator.ResolveResult{
+					Value:  nil,
+					Origin: fmt.Sprintf("var.%s", varName),
+					Error:  fmt.Errorf("LookupVariable returned unexpected error type: %T", lookupResults[1].Interface()),
+				}
+				continue
+			}
 			results[i] = decorator.ResolveResult{
 				Value:  nil,
 				Origin: fmt.Sprintf("var.%s", varName),
@@ -84,7 +92,16 @@ func (d *VarDecorator) Resolve(ctx decorator.ValueEvalContext, calls ...decorato
 			continue
 		}
 
-		exprID := lookupResults[0].String()
+		// Extract exprID with type assertion
+		exprID, ok := lookupResults[0].Interface().(string)
+		if !ok {
+			results[i] = decorator.ResolveResult{
+				Value:  nil,
+				Origin: fmt.Sprintf("var.%s", varName),
+				Error:  fmt.Errorf("LookupVariable returned non-string exprID: %T", lookupResults[0].Interface()),
+			}
+			continue
+		}
 
 		// Record reference to authorize this site before accessing
 		// Use a default parameter name for decorator resolution
@@ -117,7 +134,15 @@ func (d *VarDecorator) Resolve(ctx decorator.ValueEvalContext, calls ...decorato
 
 		// Check if RecordReference returned an error
 		if !recordResults[0].IsNil() {
-			err := recordResults[0].Interface().(error)
+			err, ok := recordResults[0].Interface().(error)
+			if !ok {
+				results[i] = decorator.ResolveResult{
+					Value:  nil,
+					Origin: fmt.Sprintf("var.%s", varName),
+					Error:  fmt.Errorf("RecordReference returned unexpected type: %T", recordResults[0].Interface()),
+				}
+				continue
+			}
 			results[i] = decorator.ResolveResult{
 				Value:  nil,
 				Origin: fmt.Sprintf("var.%s", varName),
@@ -152,7 +177,15 @@ func (d *VarDecorator) Resolve(ctx decorator.ValueEvalContext, calls ...decorato
 
 		// Check for error
 		if !accessResults[1].IsNil() {
-			err := accessResults[1].Interface().(error)
+			err, ok := accessResults[1].Interface().(error)
+			if !ok {
+				results[i] = decorator.ResolveResult{
+					Value:  nil,
+					Origin: fmt.Sprintf("var.%s", varName),
+					Error:  fmt.Errorf("Access returned unexpected error type: %T", accessResults[1].Interface()),
+				}
+				continue
+			}
 			results[i] = decorator.ResolveResult{
 				Value:  nil,
 				Origin: fmt.Sprintf("var.%s", varName),


### PR DESCRIPTION
## Summary

Replace unsafe single-value type assertions in the @var decorator with two-value assertions that fail gracefully instead of panicking if method signatures change.

## Changes

Fixed four unsafe type assertions in `runtime/decorators/var.go`:

1. **Line 78**: `LookupVariable` error return - now checks if the returned value is actually an error type
2. **Line 87**: `LookupVariable` exprID return - replaced `String()` (which can return non-useful text) with `Interface().(string)` type assertion
3. **Line 120**: `RecordReference` error return - now checks if the returned value is actually an error type
4. **Line 155**: `Access` error return - now checks if the returned value is actually an error type

Each assertion now uses the two-value form `(value, ok := ...)` and handles the `!ok` case by returning a descriptive error with the actual type received, preventing panics and making debugging easier.

## Testing

All existing tests pass:
- `TestVarDecoratorDescriptor`
- `TestVarDecoratorResolveSuccess`
- `TestVarDecoratorResolveInt`
- `TestVarDecoratorResolveBool`
- `TestVarDecoratorResolveNotFound`
- `TestVarDecoratorResolveNoPrimary`
- `TestVarDecoratorTransportAgnostic`
- `TestVarDecoratorEmptyVars`