### PR TITLE
ci: switch to Blacksmith runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
   format-check:
     name: Format Check
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -66,7 +66,7 @@ jobs:
 
   lint:
     name: Lint (${{ matrix.module }})
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       matrix:
         module: [core, runtime, cli]
@@ -92,9 +92,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [blacksmith-4vcpu-ubuntu-2404, macos-latest]
         include:
-          - os: ubuntu-latest
+          - os: blacksmith-4vcpu-ubuntu-2404
             goos: linux
             goarch: amd64
           - os: macos-latest
@@ -143,7 +143,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [blacksmith-4vcpu-ubuntu-2404, macos-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -168,7 +168,7 @@ jobs:
 
   test:
     name: Test (${{ matrix.module }})
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [lint]
     timeout-minutes: 15
     permissions:
@@ -248,7 +248,7 @@ jobs:
 
   aggregate-coverage:
     name: Aggregate Coverage
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [test]
     steps:
       - name: Checkout
@@ -289,7 +289,7 @@ jobs:
 
   summary:
     name: CI Summary
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [format-check, lint, build, nix-development, test, aggregate-coverage]
     if: always()
     steps:
@@ -335,7 +335,7 @@ jobs:
 
   latest-builds:
     name: Latest Development Builds
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [summary]
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
     steps:
@@ -371,7 +371,7 @@ jobs:
 
   release:
     name: Create Release
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Checkout


### PR DESCRIPTION
CI was taking ~3 minutes per run on GitHub's server CPUs. Tests with race detector are CPU-intensive and need faster single-core performance.

Switched all ubuntu-latest runners to blacksmith-4vcpu-ubuntu-2404. Gaming CPUs with higher single-core performance and co-located cache in the same datacenter.

Expected improvement: ~3min → ~1.5min per CI run.

macOS jobs stay on GitHub runners (Blacksmith is Linux-only).