### PR TITLE
docs: correct control flow syntax in examples

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -149,7 +149,7 @@ kubectl create secret --from-literal=key=@var.API_KEY
 
 **Planner-driven model:**
 - Planner traverses execution graph, marking expressions as touched
-- When planner hits meta-programming blockers (e.g., `@if`), it identifies ALL blockers at same depth
+- When planner hits meta-programming blockers (e.g., `if` statements), it identifies ALL blockers at same depth
 - Planner requests resolution: "I've found all blockers, resolve now"
 - Vault resolves all touched-but-unresolved expressions (batched by decorator)
 - Planner evaluates meta-programming and continues traversing
@@ -1416,12 +1416,12 @@ CommandIR{
 vault.ResolveAllTouched()
 // Marks all touched as resolved, generates DisplayIDs
 
-// Future (with @if, @for): Multiple waves
+// Future (with if, for): Multiple waves
 // Wave 1: Resolve expressions needed for blockers
 vault.MarkTouched("ENV")
 vault.ResolveAllTouched()
 
-// Evaluate blocker: @if(@var.ENV == "prod")
+// Evaluate blocker: if @var.ENV == "prod"
 value, _ := vault.Access("ENV", "condition")
 
 // Wave 2: Resolve expressions in taken branch
@@ -1476,7 +1476,7 @@ echo "Hello, @var.NAME"  # Variable in shell command string
 
 ```opal
 var ENV = "prod"
-@if(@var.ENV == "prod") {  # Variable in condition
+if @var.ENV == "prod" {  # Variable in condition
     echo "Production"
 }
 ```

--- a/docs/DECORATOR_GUIDE.md
+++ b/docs/DECORATOR_GUIDE.md
@@ -337,8 +337,8 @@ func awsSecretHandler(ctx ExecutionContext, args []Param) (*secret.Handle, error
 ```
 
 **Safe operations (always available):**
-- `handle.ID()` - Opaque display ID: `opal:s:3J98t56A`
-- `handle.IDWithEmoji()` - Display with emoji: `🔒 opal:s:3J98t56A`
+- `handle.ID()` - Opaque display ID: `opal:3J98t56A`
+- `handle.IDWithEmoji()` - Display with emoji: `🔒 opal:3J98t56A`
 - `handle.Mask(3)` - Masked display: `abc***xyz`
 - `handle.Len()` - Length without exposing value
 - `handle.Equal(other)` - Constant-time comparison
@@ -771,7 +771,7 @@ Even though "Fast" completes first, final output is reordered by step ID for det
 **Logical order** (outside to inside):
 1. **Time constraints**: `@timeout`
 2. **Error handling**: `@retry`
-3. **Control flow**: `@parallel`, `@when`
+3. **Control flow**: `@parallel`
 4. **Logging/monitoring**: `@log`
 5. **Execution**: shell commands, `@cmd`
 
@@ -1032,7 +1032,7 @@ type ExecutionContext interface {
 
 Decorators have **no direct access to I/O streams**. All output flows through the executor which:
 1. Maintains a registry of secret values from value decorator resolutions
-2. Automatically replaces secret values with plan placeholders: `opal:s:ID`
+2. Automatically replaces secret values with plan placeholders: `opal:ID`
 3. Ensures audit trail shows which secrets were used without exposing values
 
 This prevents decorators from accidentally (or maliciously) leaking secrets.


### PR DESCRIPTION
Documentation was incorrectly showing `@if`/`@for`/`@when` syntax in source code examples. These are language keywords (`if`/`for`/`when`), not decorators.

The confusion came from plan output, which shows control flow with `@` prefix to indicate evaluated constructs. But in source code, you write `if ENV == "prod"`, not `@if(ENV == "prod")`.

Also clarified plan output format using Logic Node pattern:
- Shows evaluation results (`-> true`, `-> matched "production"`)
- Only shows taken branches (untaken branches are pruned)
- Variables in untaken branches aren't resolved (can't show them)

Fixed DisplayID format from `opal:s:ID` to current `opal:ID` format and removed deprecated `@when` decorator reference.