### PR TITLE
feat: add IR builder for planner rewrite

### DIFF
--- a/runtime/planner/ir.go
+++ b/runtime/planner/ir.go
@@ -30,6 +30,7 @@ const (
 	StmtCommand StatementKind = iota // Shell command or decorator invocation
 	StmtVarDecl                      // Variable declaration
 	StmtBlocker                      // Control flow (if/when/for)
+	StmtTry                          // Try/catch/finally error handling
 )
 
 // StatementIR represents a statement in the execution graph.
@@ -42,6 +43,7 @@ type StatementIR struct {
 	Command *CommandStmtIR // For StmtCommand
 	VarDecl *VarDeclIR     // For StmtVarDecl
 	Blocker *BlockerIR     // For StmtBlocker
+	Try     *TryIR         // For StmtTry
 }
 
 // CommandStmtIR represents a command statement.
@@ -84,6 +86,23 @@ type BlockerIR struct {
 	// For-loop specific
 	LoopVar    string  // Loop variable name (for "for x in ...")
 	Collection *ExprIR // Collection expression (for "for x in collection")
+
+	// When-specific (pattern matching)
+	Arms []*WhenArmIR // Pattern arms (for "when expr { pattern -> ... }")
+}
+
+// WhenArmIR represents a single arm in a when statement.
+type WhenArmIR struct {
+	Pattern *ExprIR        // Pattern to match (literal, regex, range, else)
+	Body    []*StatementIR // Statements to execute if pattern matches
+}
+
+// TryIR represents try/catch/finally error handling.
+type TryIR struct {
+	TryBlock     []*StatementIR // Statements in try block
+	CatchBlock   []*StatementIR // Statements in catch block (optional)
+	FinallyBlock []*StatementIR // Statements in finally block (optional)
+	ErrorVar     string         // Variable name for caught error (optional)
 }
 
 // ScopeStack tracks variable scopes during IR building.


### PR DESCRIPTION
The planner (3118 lines) mixes too many concerns. This adds the IR Builder component that walks parser events and builds an ExecutionGraph - a pure structural pass with no resolution or evaluation.

Part of MR #2 (Phase 2b) for planner rewrite. Follows PR #98 which added expression types and IR data structures.

Added ir_builder.go (~870 lines) that handles:
- Variable declarations with scope tracking
- Shell commands with decorator expressions
- If/else statements and else-if chains
- Binary expressions (==, !=, <, >, <=, >=, &&, ||)
- Expression parsing (@var.X, @env.HOME, literals)

Parser pattern for binary expressions: The parser emits the left operand before NodeBinaryExpr (which only contains operator and right operand). The IR builder handles this by parsing the primary expression first, then checking if a binary expression follows.

Token types not text: Operator tokens like EQ_EQ have empty text - use token types to determine operator strings.

Scope tracking: IR Builder owns variable name → exprID mapping via ScopeStack. This separates concerns from Vault (which stores values).

Next: Resolver (wave-based resolution), Emitter (plan generation), then wire up new planner.