### PR TITLE
ci: harden runtime test execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,29 +325,18 @@ jobs:
           restore-prefixes-first-match: nix-${{ runner.os }}-
           gc-max-store-size-linux: 1073741824
 
-      - name: Cache Go modules
-        uses: actions/cache@v4
-        with:
-          path: |
-            ${{ runner.temp }}/go-build
-            ${{ runner.temp }}/go-mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
       - name: Run module tests
         env:
           TMPDIR: ${{ runner.temp }}/go-tmp
           GOTMPDIR: ${{ runner.temp }}/go-tmp
-          GOCACHE: ${{ runner.temp }}/go-build
-          GOMODCACHE: ${{ runner.temp }}/go-mod
         run: |
           set -euo pipefail
-          mkdir -p "$TMPDIR" "$GOCACHE" "$GOMODCACHE"
+          mkdir -p "$TMPDIR"
           nix develop -c bash -c '
+            go clean -cache -testcache
             echo "Running ${{ matrix.module }} module tests..."
             cd ${{ matrix.module }}
-            go test -v -race -coverprofile=../coverage-${{ matrix.module }}.out -covermode=atomic ./...
+            go test -v -race -coverprofile=../coverage-${{ matrix.module }}.out -covermode=atomic ./... 2>&1 | tee /tmp/test-${{ matrix.module }}.log
           '
 
       - name: Upload coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,16 +329,28 @@ jobs:
         env:
           TMPDIR: ${{ runner.temp }}/go-tmp
           GOTMPDIR: ${{ runner.temp }}/go-tmp
+          GOCACHE: ${{ runner.temp }}/go-build
+          GOMODCACHE: ${{ runner.temp }}/go-mod
+          TEST_LOG: ${{ runner.temp }}/test-${{ matrix.module }}.log
         run: |
           set -euo pipefail
-          mkdir -p "$TMPDIR"
+          rm -rf "$GOCACHE" "$GOMODCACHE"
+          mkdir -p "$TMPDIR" "$GOCACHE" "$GOMODCACHE"
           nix develop -c bash -c '
             set -euo pipefail
-            go clean -cache -testcache
             echo "Running ${{ matrix.module }} module tests..."
+            echo "Using GOCACHE=$GOCACHE"
+            echo "Using GOMODCACHE=$GOMODCACHE"
             cd ${{ matrix.module }}
-            go test -v -race -coverprofile=../coverage-${{ matrix.module }}.out -covermode=atomic ./... 2>&1 | tee /tmp/test-${{ matrix.module }}.log
+            go test -v -race -coverprofile=../coverage-${{ matrix.module }}.out -covermode=atomic ./... 2>&1 | tee "$TEST_LOG"
           '
+
+      - name: Upload failed test log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-log-${{ matrix.module }}
+          path: ${{ runner.temp }}/test-${{ matrix.module }}.log
 
       - name: Upload coverage
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,6 +333,7 @@ jobs:
           set -euo pipefail
           mkdir -p "$TMPDIR"
           nix develop -c bash -c '
+            set -euo pipefail
             go clean -cache -testcache
             echo "Running ${{ matrix.module }} module tests..."
             cd ${{ matrix.module }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,6 +351,7 @@ jobs:
         with:
           name: test-log-${{ matrix.module }}
           path: ${{ runner.temp }}/test-${{ matrix.module }}.log
+          if-no-files-found: ignore
 
       - name: Upload coverage
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- remove Go module/build cache restore from the matrix test job to avoid tar restore corruption on self-hosted runners
- simplify runtime test env to TMPDIR and GOTMPDIR and let Go use default caches inside nix develop
- add go clean -cache -testcache and tee output to a log file so failures are diagnosable

## Why
Recent main failures showed runtime tests exiting quickly after cache restore warnings. This change prefers deterministic test execution over cache hit speed.